### PR TITLE
Improve "Types" and "Constructors" sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ We assume you use the latest PyTorch and Numpy.
 
 ## Types
 
-| Numpy        | PyTorch                                                      |
-|:-------------|:-------------------------------------------------------------|
-| `np.ndarray` | `torch.Tensor or torch.tensor`                               |
-| `np.float32` | `torch.FloatTensor or torch.tensor(x, dtype = torch.float)`  |
-| `np.float64` | `torch.DoubleTensor or torch.tensor(x, dtype = torch.double` |
-| `np.float16` | `torch.HalfTensor or torch.tensor(x, dtype = torch.half)`    |
-| `np.int8`    | `torch.CharTensor or torch.tensor(x, dtype = torch.int8)`    |
-| `np.uint8`   | `torch.ByteTensor or torch.tensor(x, dtype = torch.uint8)`   |
-| `np.int16`   | `torch.ShortTensor or torch.tensor(x, dtype = torch.short)`  |
-| `np.int32`   | `torch.IntTensor or torch.tensor(x, dtype = torch.int)`      |
-| `np.int64`   | `torch.LongTensor or torch.tensor(x, dtype = torch.long)`    |
+| Numpy        | PyTorch                         |
+|:-------------|:--------------------------------|
+| `np.ndarray` | `torch.Tensor`                  |
+| `np.float32` | `torch.float32 or torch.float`  |
+| `np.float64` | `torch.float64 or torch.double` |
+| `np.float16` | `torch.float16 or torch.half`   |
+| `np.int8`    | `torch.int8`                    |
+| `np.uint8`   | `torch.uint8`                   |
+| `np.int16`   | `torch.int16 or torch.short`    |
+| `np.int32`   | `torch.int32 or torch.int`      |
+| `np.int64`   | `torch.int64 or torch.long`     |
 
 
 ## Constructors
@@ -27,7 +27,7 @@ We assume you use the latest PyTorch and Numpy.
 
 | Numpy              | PyTorch               |
 |:-------------------|:----------------------|
-| `np.empty((2, 3))` | `torch.empty((2, 3))` |
+| `np.empty((2, 3))` | `torch.empty(2, 3)`   |
 | `np.empty_like(x)` | `torch.empty_like(x)` |
 | `np.eye`           | `torch.eye`           |
 | `np.identity`      | `torch.eye`           |
@@ -38,18 +38,19 @@ We assume you use the latest PyTorch and Numpy.
 
 ### From existing data
 
-| Numpy                        | PyTorch                             |
-|:-----------------------------|:------------------------------------|
-| `np.array([[1, 2], [3, 4]])` | `torch.tensor([[1, 2], [3, 4])`     |
-| `x.copy()`                   | `x.clone()`                         |
-| `np.fromfile(file)`          | `torch.tensor(torch.Storage(file))` |
-| `np.frombuffer`              |                                     |
-| `np.fromfunction`            |                                     |
-| `np.fromiter`                |                                     |
-| `np.fromstring`              |                                     |
-| `np.load`                    | `torch.load`                        |
-| `np.loadtxt`                 |                                     |
-| `np.concatenate`             | `torch.cat`                         |
+| Numpy                                                              | PyTorch                                         |
+|:-------------------------------------------------------------------|:------------------------------------------------|
+| `np.array([[1, 2], [3, 4]])`                                       | `torch.tensor([[1, 2], [3, 4])`                 |
+| `np.array([3.2, 4.3], dtype=np.float16) or np.float16([3.2, 4.3])` | `torch.tensor([3.2, 4.3], dtype=torch.float16)` |
+| `x.copy()`                                                         | `x.clone()`                                     |
+| `np.fromfile(file)`                                                | `torch.tensor(torch.Storage(file))`             |
+| `np.frombuffer`                                                    |                                                 |
+| `np.fromfunction`                                                  |                                                 |
+| `np.fromiter`                                                      |                                                 |
+| `np.fromstring`                                                    |                                                 |
+| `np.load`                                                          | `torch.load`                                    |
+| `np.loadtxt`                                                       |                                                 |
+| `np.concatenate`                                                   | `torch.cat`                                     |
 
 ### Numerical ranges
 

--- a/conversions.yaml
+++ b/conversions.yaml
@@ -1,27 +1,27 @@
 types:
   - numpy: np.ndarray
-    pytorch: torch.Tensor or torch.tensor
+    pytorch: torch.Tensor
   - numpy: np.float32
-    pytorch: torch.FloatTensor or torch.tensor(x, dtype = torch.float)
+    pytorch: torch.float32 or torch.float
   - numpy: np.float64
-    pytorch: torch.DoubleTensor or torch.tensor(x, dtype = torch.double
+    pytorch: torch.float64 or torch.double
   - numpy: np.float16
-    pytorch: torch.HalfTensor or torch.tensor(x, dtype = torch.half)
+    pytorch: torch.float16 or torch.half
   - numpy: np.int8
-    pytorch: torch.CharTensor or torch.tensor(x, dtype = torch.int8)
+    pytorch: torch.int8
   - numpy: np.uint8
-    pytorch: torch.ByteTensor or torch.tensor(x, dtype = torch.uint8)
+    pytorch: torch.uint8
   - numpy: np.int16
-    pytorch: torch.ShortTensor or torch.tensor(x, dtype = torch.short)
+    pytorch: torch.int16 or torch.short
   - numpy: np.int32
-    pytorch: torch.IntTensor or torch.tensor(x, dtype = torch.int)
+    pytorch: torch.int32 or torch.int
   - numpy: np.int64
-    pytorch: torch.LongTensor or torch.tensor(x, dtype = torch.long)
+    pytorch: torch.int64 or torch.long
 
 constructors:
   ones and zeros:
     - numpy: np.empty((2, 3))
-      pytorch: torch.empty((2, 3))
+      pytorch: torch.empty(2, 3)
     - numpy: np.empty_like(x)
       pytorch: torch.empty_like(x)
     - numpy: np.eye
@@ -39,6 +39,8 @@ constructors:
   from existing data:
     - numpy: np.array([[1, 2], [3, 4]])
       pytorch: torch.tensor([[1, 2], [3, 4])
+    - numpy: np.array([3.2, 4.3], dtype=np.float16) or np.float16([3.2, 4.3])
+      pytorch: torch.tensor([3.2, 4.3], dtype=torch.float16)
     - numpy: x.copy()
       pytorch: x.clone()
     - numpy: np.fromfile(file)


### PR DESCRIPTION
- Remove np.ndarray <-> torch.tensor conversion, because
  np.ndarray is a type and a factory function (like torch.Tensor), but
  torch.tensor is just a function and can't be used as a type.
- Add numpy-style torch dtypes. They should be favored because they have
  the same names as their numpy counterparts.
- Remove torch.*Tensor entries, because they are obsolete since 0.4.0 and
  will probably be deprecated soon (https://github.com/pytorch/pytorch/issues/7900)
- Remove torch.tensor() entries because they are not types but show tensor
  creation.
  Instead, add a single torch.tensor(..., dtype=...) example below in the
  "Constructors"/"from existing data" section.
  It should immediately be clear that other dtypes can be used here instead of
  float16.
- Remove unnecessary braces from torch.empty() call